### PR TITLE
Fix unexpected deleting indentation

### DIFF
--- a/lark-mode.el
+++ b/lark-mode.el
@@ -112,6 +112,7 @@ Highlight the 1st result."
         (indent (or indent (lark-mode--calculate-indentation)))
         (shift-amount nil)
         (beg (point-at-bol)))
+    (beginning-of-line)
     (skip-chars-forward " \t")
     (if (null indent)
         (goto-char (- (point-max) pos))


### PR DESCRIPTION
Fixes #1.

The issue appeared after commit 8f5dcb26c38b5c6417001327189f0c71f8163afd since the `point-at-bol` function doesn't move point. Now the indentation is behaving as intended again, and the linter doesn't complain. 